### PR TITLE
fix(package): old engine restriction

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -21,9 +21,6 @@
     "axios": "^0.19.0",
     "express": "~4.16.2"
   },
-  "engines": {
-    "node": "~6.11.1"
-  },
   "main": "index",
   "version": "0.1.0",
   "devDependencies": {


### PR DESCRIPTION
This PR fixes the following error thrown when hitting the `GET /` endpoint of the server.
We can alternatively keep the `engines` field but loosen the version restriction.

## Environments

1. PC
   * OS: Pro 10 1809
   * `now`: 15.6.2
   * `node`: 8.11.4
2. Mac
   * OS: Mojave 10.14.5
   * `now`: 15.6.2
   * `node`: 9.8.0

## Logs

### Before

```console
$ npm start

> gatekeeper@0.1.0 start issueist/server
> now dev --port 8080

> Now CLI 15.6.2 dev (beta) — https://zeit.co/feedback/dev
> Ready! Available at http://localhost:8080
> GET /
> Building @now/node:index.js
downloading user files...
installing dependencies for user's code...
{ Error: found `engines` in `package.json` with an unsupported node range: ~6.11.1
please use `10.x` or `8.10.x` instead
    at Object.getSupportedNodeVersion (<path-omitted>\co.zeit.now\Caches\dev\builders\node_modules\@now\build-utils\dist\fs\node-version.js:28:19)
    at Object.getNodeVersion (<path-omitted>\co.zeit.now\Caches\dev\builders\node_modules\@now\build-utils\dist\fs\run-user-scripts.js:64:27)
    at <anonymous>
  message:
   'found `engines` in `package.json` with an unsupported node range: ~6.11.1\nplease use `10.x` or `8.10.x` instead' }
```

### After

```console
$ npm start

> gatekeeper@0.1.0 start issueist/server
> now dev --port 8080

> Now CLI 15.6.2 dev (beta) — https://zeit.co/feedback/dev
> Ready! Available at http://localhost:8080
> GET /
> Building @now/node:index.js
downloading user files...
installing dependencies for user's code...
missing `engines` in `package.json`, using default range: 8.10.x
```

## See more

https://github.com/prose/gatekeeper/pull/31