### PR TITLE
[DO NOT MERGE] Delayed issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@material-ui/icons": "^3.0.2",
     "github-api": "^3.2.2",
     "localforage": "^1.7.3",
+    "moment": "^2.24.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",
-    "react-toastify": "^5.3.1"
+    "react-toastify": "^5.3.1",
+    "uuid": "^3.3.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -74,7 +74,7 @@ export default class App extends Component {
       </div>
     );
     return (
-      <div style={{width: '400px', height: '600px'}}>
+      <div style={{height: '600px'}}>
         <AppBar onClickMenu={() => this.toggleDrawer(true)}/>
         {!this.state.token ? <LoginPage loading={this.state.loading} onSuccess={this.onSuccess} onFailure={this.onFailure}/> : <CreateIssuePage token={this.state.token}/>}
         <Drawer open={this.state.open} onClose={() => this.toggleDrawer(false)}>

--- a/src/pages/create-issue/delay-issue.jsx
+++ b/src/pages/create-issue/delay-issue.jsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Checkbox,
@@ -7,31 +7,28 @@ import {
   TextField,
 } from '@material-ui/core';
 
-class DelayIssue extends Component {
-
-
-  render() {
-    return (
+const DelayIssue = ({ isChecked, handleChange, handleChangeChecked, date }) =>
+    (
       <>
         <FormControl fullWidth>
           <FormControlLabel
             control={
               <Checkbox
-                checked={this.props.isChecked}
-                onChange={this.props.handleChangeChecked}
+                checked={isChecked}
+                onChange={handleChangeChecked}
                 name="delayIssueChecked"
                 color="primary"
               />
             }
             label="Delay Issue"
           />
-          {this.props.isChecked && (
+          {isChecked && (
             <TextField
               id="datetime-local"
-              label="Next appointment"
+              label="Publication date"
               type="datetime-local"
-              onChange={this.props.handleChange}
-              defaultValue={this.props.date}
+              onChange={handleChange}
+              defaultValue={date}
               name="delayIssueDate"
               InputLabelProps={{
                 shrink: true,
@@ -41,11 +38,11 @@ class DelayIssue extends Component {
         </FormControl>
       </>
     );
-  }
-}
 
 DelayIssue.propTypes = {
   isChecked: PropTypes.bool,
-  handleChange: PropTypes.func
+  handleChange: PropTypes.func,
+  handleChangeChecked: PropTypes.func,
+  date: PropTypes.string,
 }
 export default DelayIssue;

--- a/src/pages/create-issue/delay-issue.jsx
+++ b/src/pages/create-issue/delay-issue.jsx
@@ -1,0 +1,51 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  TextField,
+} from '@material-ui/core';
+
+class DelayIssue extends Component {
+
+
+  render() {
+    return (
+      <>
+        <FormControl fullWidth>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={this.props.isChecked}
+                onChange={this.props.handleChangeChecked}
+                name="delayIssueChecked"
+                color="primary"
+              />
+            }
+            label="Delay Issue"
+          />
+          {this.props.isChecked && (
+            <TextField
+              id="datetime-local"
+              label="Next appointment"
+              type="datetime-local"
+              onChange={this.props.handleChange}
+              defaultValue={this.props.date}
+              name="delayIssueDate"
+              InputLabelProps={{
+                shrink: true,
+              }}
+            />
+          )}
+        </FormControl>
+      </>
+    );
+  }
+}
+
+DelayIssue.propTypes = {
+  isChecked: PropTypes.bool,
+  handleChange: PropTypes.func
+}
+export default DelayIssue;

--- a/src/pages/create-issue/index.jsx
+++ b/src/pages/create-issue/index.jsx
@@ -35,7 +35,7 @@ const styles = theme => ({
   },
   wrapper: {
     paddingTop: '20px',
-       position: 'relative',
+    position: 'relative',
   },
   buttonProgress: {
     position: 'absolute',

--- a/src/services/delayed-processor/__test__/index.test.js
+++ b/src/services/delayed-processor/__test__/index.test.js
@@ -1,0 +1,15 @@
+import { delayIssue } from '../index.js'
+import {store, retrieve} from '../../storage'
+
+jest.mock('../../storage')
+jest.mock('uuid/v4', () => () => 'mockeduuid')
+
+test('delayIssue stores the new issue with a uuid', async () => {
+  const newIssue = {user: 'test', repo: 'test', title: 'test', body: 'test', date: '2019-06-29T23:42'};
+  await delayIssue(newIssue)
+  expect(store).toBeCalledWith('delayedIssues', [{
+   id: 'mockeduuid',
+    ...newIssue
+  }])
+})
+

--- a/src/services/delayed-processor/index.js
+++ b/src/services/delayed-processor/index.js
@@ -1,0 +1,24 @@
+import {store, retrieve} from '../storage';
+
+export const delayIssue = async (ghIssue, meta) => {
+  console.log('edlayign issue')
+  let delayedIssues = await retrieve('delayedIssues') || []
+  let newIssue = {
+    ghIssue,
+    ...meta
+  };
+  console.log([...delayedIssues, newIssue]);
+  await store('delayedIssues', [...delayedIssues, newIssue]);
+};
+
+
+window.setInterval(async () => {
+  console.log('checking delayed issues...');
+  let delayedIssues = await retrieve('delayedIssues');
+
+  if (delayedIssues) {
+    delayedIssues.forEach(issue => {
+      console.log('issue: ', issue);
+    });
+  }
+}, 5000);

--- a/src/services/delayed-processor/index.js
+++ b/src/services/delayed-processor/index.js
@@ -1,4 +1,4 @@
-import  uuidv4  from 'uuid/v4';
+import uuidv4 from 'uuid/v4';
 import {store, retrieve} from '../storage';
 
 let existingPollingId;
@@ -6,11 +6,10 @@ let existingPollingId;
 /**
  * Stores an issue to be published at a later date.
  */
-export const delayIssue = async (newIssue) => {
-  let delayedIssues = await retrieve('delayedIssues') || []
+export const delayIssue = async newIssue => {
+  let delayedIssues = (await retrieve('delayedIssues')) || [];
   await store('delayedIssues', [...delayedIssues, {id: uuidv4(), ...newIssue}]);
 };
-
 
 /**
  * Continuously polls the storage for delayed issues.
@@ -18,21 +17,50 @@ export const delayIssue = async (newIssue) => {
  * or not the issue should be published.
  * Upon successfully publishing an issue, it is removed from storage.
  */
-export const startPollingDelayedIssues = (gh) => {
+export const startPollingDelayedIssues = gh => {
   if (existingPollingId) {
     window.clearInterval(existingPollingId);
   }
 
-  existingPollingId = window.setInterval(async () => {
-    console.log('Checking for delayed issues');
-    let delayedIssues = await retrieve('delayedIssues');
+  existingPollingId = window.setTimeout(
+    async () => await pollPublishAndRemove(gh),
+    5000,
+  );
+};
 
-    let idsToRemove = [];
-    delayedIssues.forEach(async issue => {
+/**
+ * Runs the actual logic for finding delayed issues, publishing them,
+ * and then removing them. Additionally creates a new setTimeout
+ * so that new delayed issues will be polled.
+ */
+async function pollPublishAndRemove(gh) {
+  let delayedIssues = await retrieve('delayedIssues');
+  let idsToRemove = await publishDelayedIssues(delayedIssues, gh);
+
+  idsToRemove.forEach(id => {
+    delayedIssues = delayedIssues.filter(issue => issue.id !== id);
+  });
+
+  await store('delayedIssues', delayedIssues);
+
+  existingPollingId = window.setTimeout(
+    async () => await pollPublishAndRemove(gh),
+    5000,
+  );
+}
+
+/**
+ * Publishes an array of issues to GitHub, then returns an array
+ * with their ids so they can be removed.
+ */
+async function publishDelayedIssues(delayedIssues, gh) {
+  let idsToRemove = [];
+  await Promise.all(
+    delayedIssues.map(async issue => {
       if (Date.now() > new Date(issue.date).getTime()) {
         const {id, user, repo, title, body} = issue;
 
-        const ghIssues = gh.getIssues(user, repo)
+        const ghIssues = gh.getIssues(user, repo);
         await ghIssues.createIssue({
           title,
           body,
@@ -41,19 +69,13 @@ export const startPollingDelayedIssues = (gh) => {
         // Issue successfully published, now set it for removal
         idsToRemove.push(id);
       }
-    });
-
-    idsToRemove.forEach(id => {
-      delayedIssues = delayedIssues.filter(issue => issue.id !== id)
-    })
-
-    await store('delayedIssues', delayedIssues);
-  }, 10000);
+    }),
+  );
+  return idsToRemove;
 }
 
 export const stopPollingDelayedIssues = () => {
   if (existingPollingId) {
-    window.clearInterval(existingPollingId)
+    window.clearInterval(existingPollingId);
   }
-}
-
+};

--- a/src/services/delayed-processor/index.js
+++ b/src/services/delayed-processor/index.js
@@ -1,24 +1,59 @@
+import  uuidv4  from 'uuid/v4';
 import {store, retrieve} from '../storage';
 
-export const delayIssue = async (ghIssue, meta) => {
-  console.log('edlayign issue')
+let existingPollingId;
+
+/**
+ * Stores an issue to be published at a later date.
+ */
+export const delayIssue = async (newIssue) => {
   let delayedIssues = await retrieve('delayedIssues') || []
-  let newIssue = {
-    ghIssue,
-    ...meta
-  };
-  console.log([...delayedIssues, newIssue]);
-  await store('delayedIssues', [...delayedIssues, newIssue]);
+  await store('delayedIssues', [...delayedIssues, {id: uuidv4(), ...newIssue}]);
 };
 
 
-window.setInterval(async () => {
-  console.log('checking delayed issues...');
-  let delayedIssues = await retrieve('delayedIssues');
-
-  if (delayedIssues) {
-    delayedIssues.forEach(issue => {
-      console.log('issue: ', issue);
-    });
+/**
+ * Continuously polls the storage for delayed issues.
+ * Compares their date to the current date in order to determine whether
+ * or not the issue should be published.
+ * Upon successfully publishing an issue, it is removed from storage.
+ */
+export const startPollingDelayedIssues = (gh) => {
+  if (existingPollingId) {
+    window.clearInterval(existingPollingId);
   }
-}, 5000);
+
+  existingPollingId = window.setInterval(async () => {
+    console.log('Checking for delayed issues');
+    let delayedIssues = await retrieve('delayedIssues');
+
+    let idsToRemove = [];
+    delayedIssues.forEach(async issue => {
+      if (Date.now() > new Date(issue.date).getTime()) {
+        const {id, user, repo, title, body} = issue;
+
+        const ghIssues = gh.getIssues(user, repo)
+        await ghIssues.createIssue({
+          title,
+          body,
+        });
+
+        // Issue successfully published, now set it for removal
+        idsToRemove.push(id);
+      }
+    });
+
+    idsToRemove.forEach(id => {
+      delayedIssues = delayedIssues.filter(issue => issue.id !== id)
+    })
+
+    await store('delayedIssues', delayedIssues);
+  }, 10000);
+}
+
+export const stopPollingDelayedIssues = () => {
+  if (existingPollingId) {
+    window.clearInterval(existingPollingId)
+  }
+}
+


### PR DESCRIPTION
## Note: Currently broken
Right now, if the delayed issue polling is running when a new delayed issue is created by the user, the store wont accept the new issue and it will be lost. This is because the delayed issues in the store are updated by the polling function when it is done.
One potential solution is to have the delayed issue creator wait on a mutex/lock for the store, another, probably simpler solution, is to have a buffer/queue for delayed issues that the delayed issue polling reconciles with when done polling.

Addresses https://github.com/kaufmann42/issueist/issues/24, adds support for delaying issues to be published at a later date.

Note, the extension needs to be open for a delayed issue to be published.

This PR also removes a set width on the App that was causing horizontal overflow